### PR TITLE
Fix race condition in transferring data from numpy to cupy

### DIFF
--- a/src/katcbf_vlbi_resample/cupy_bridge.py
+++ b/src/katcbf_vlbi_resample/cupy_bridge.py
@@ -21,7 +21,7 @@ class AsCupy(ChunkwiseStream[xr.DataArray, xr.DataArray]):
         self.is_cupy = True
 
     def _transform(self, chunk: xr.DataArray) -> xr.DataArray:
-        return as_cupy(chunk)
+        return as_cupy(chunk, blocking=True)
 
 
 class AsNumpy:

--- a/src/katcbf_vlbi_resample/resample.py
+++ b/src/katcbf_vlbi_resample/resample.py
@@ -275,8 +275,8 @@ class Resample:
         self.is_cupy = input_data.is_cupy
         if input_data.is_cupy:
             # Transfer filters to the GPU once
-            self._fir = as_cupy(self._fir)
-            self._hilbert = as_cupy(self._hilbert)
+            self._fir = as_cupy(self._fir, blocking=True)
+            self._hilbert = as_cupy(self._hilbert, blocking=True)
 
     def __iter__(self) -> Iterator[xr.DataArray]:
         buffer = None

--- a/src/katcbf_vlbi_resample/utils.py
+++ b/src/katcbf_vlbi_resample/utils.py
@@ -72,6 +72,6 @@ def is_cupy(array: xr.DataArray) -> bool:
     return isinstance(array.data, cp.ndarray)
 
 
-def as_cupy(array: xr.DataArray) -> xr.DataArray:
+def as_cupy(array: xr.DataArray, blocking: bool = False) -> xr.DataArray:
     """Convert `array` to hold a cupy array if necessary."""
-    return array.copy(data=cp.asarray(array.data))
+    return array.copy(data=cp.asarray(array.data, blocking=blocking))

--- a/src/katcbf_vlbi_resample/xrsig.py
+++ b/src/katcbf_vlbi_resample/xrsig.py
@@ -12,7 +12,7 @@ import scipy.fft
 import scipy.signal
 import xarray as xr
 
-from .utils import as_cupy, is_cupy
+from .utils import is_cupy
 
 
 def _wrap_cupyx_upfirdn(h: cp.ndarray, x: cp.ndarray, *args, **kwargs):
@@ -110,11 +110,12 @@ def convolve1d(
     It always performs 1D convolution, using the `dim` argument to select
     the axis over which to convolve.
     """
-    use_cupy = is_cupy(in1) or is_cupy(in2)
+    assert is_cupy(in1) == is_cupy(in2)
+    use_cupy = is_cupy(in1)
     return xr.apply_ufunc(
         _wrap_cupyx_convolve1d if use_cupy else scipy.signal.convolve,
-        as_cupy(in1) if use_cupy else in1,  # TODO: avoid copying every time!
-        as_cupy(in2) if use_cupy else in2,
+        in1,
+        in2,
         vectorize=not use_cupy,  # Doesn't work for cupy
         input_core_dims=[[dim], [dim]],
         output_core_dims=[(dim,)],


### PR DESCRIPTION
cp.asarray is non-blocking by default, and it does not keep a reference to the source during the transfer, so if it is garbage collected then the memory can be reallocated and overwritten while still being read.

Fix HDF5Reader by keeping an explicit deque of transfer buffers, and tracking events to ensure they're not reused before transfer is complete.

Change most other uses of cp.asarray (generally used via as_cupy) since performance isn't critical.