### PR TITLE
Optimisations for low --samples-per-frame

### DIFF
--- a/src/katcbf_vlbi_resample/mk.py
+++ b/src/katcbf_vlbi_resample/mk.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, National Research Foundation (SARAO)
+# Copyright (c) 2024-2025, National Research Foundation (SARAO)
 
 """Main script for resampling MeerKAT HDF5 beamformer files."""
 

--- a/src/katcbf_vlbi_resample/vdif_writer.py
+++ b/src/katcbf_vlbi_resample/vdif_writer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, National Research Foundation (SARAO)
+# Copyright (c) 2024-2025, National Research Foundation (SARAO)
 
 """Encode data to VDIF frames."""
 


### PR DESCRIPTION
- Reduce default --samples-per-frame to JIVE-recommended value
- Optimise VDIFFormatter for this case (closes NGC-1566)
- Initialise VDIF ref epoch to use the global sync time (closes NGC-1586).