### PR TITLE
Modify API to better support katgpucbf

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -10,7 +10,6 @@ from unittest import mock
 
 for module in ["cupy", "cupyx", "cupyx.scipy", "cupyx.scipy.fft", "cupyx.scipy.signal"]:
     sys.modules[module] = mock.MagicMock()
-sys.modules["cupy"].__version__ = "13.6.0"
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information

--- a/src/katcbf_vlbi_resample/cupy_bridge.py
+++ b/src/katcbf_vlbi_resample/cupy_bridge.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2024, National Research Foundation (SARAO)
+# Copyright (c) 2024-2026 National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy
@@ -31,11 +31,15 @@ from .utils import as_cupy, stream_future
 # We don't list cupy in project requirements because there are multiple
 # packages that could provide it (e.g. cupy-cudaNNx for binary wheels),
 # so we check the dependencies at import time.
-_cupy_version = packaging.version.Version(cp.__version__)
-if _cupy_version < packaging.version.Version("13.4"):
-    raise ImportError("cupy >= 13.4 is required", name="cupy")
-if _cupy_version == packaging.version.Version("13.5.1"):
-    raise ImportError("cupy 13.5.1 is not supported due to a bug", name="cupy")
+#
+# When building documentation we mock out cupy in a way that
+# would break these tests; in that case, just skip them.
+if hasattr(cp, "__version__") and isinstance(cp.__version__, str):
+    _cupy_version = packaging.version.Version(cp.__version__)
+    if _cupy_version < packaging.version.Version("13.4"):
+        raise ImportError("cupy >= 13.4 is required", name="cupy")
+    if _cupy_version == packaging.version.Version("13.5.1"):
+        raise ImportError("cupy 13.5.1 is not supported due to a bug", name="cupy")
 
 
 class AsCupy(ChunkwiseStream[xr.DataArray, xr.DataArray]):

--- a/src/katcbf_vlbi_resample/mk.py
+++ b/src/katcbf_vlbi_resample/mk.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2024-2025, National Research Foundation (SARAO)
+# Copyright (c) 2024-2026, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/src/katcbf_vlbi_resample/parameters.py
+++ b/src/katcbf_vlbi_resample/parameters.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2024, National Research Foundation (SARAO)
+# Copyright (c) 2024, 2026 National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/src/katcbf_vlbi_resample/parameters.py
+++ b/src/katcbf_vlbi_resample/parameters.py
@@ -20,14 +20,6 @@ from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
-class StreamParameters:
-    """Parameters of a time-domain stream of samples."""
-
-    bandwidth: float  # Hz
-    center_freq: float  # Hz
-
-
-@dataclass(frozen=True)
 class ResampleParameters:
     """Parameters controlling the resampling process."""
 

--- a/src/katcbf_vlbi_resample/polarisation.py
+++ b/src/katcbf_vlbi_resample/polarisation.py
@@ -23,7 +23,7 @@ space. That is valid for MeerKAT for *not* for KAT-7.
 
 import math
 import re
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 
 import cupy as cp
 import numpy as np
@@ -65,13 +65,13 @@ def parse_pol(spec: str) -> np.ndarray:
     return v
 
 
-def to_linear(pols: list[str]) -> np.ndarray:
+def to_linear(pols: Sequence[str]) -> np.ndarray:
     """Create a Jones matrix to convert to a linear coordinate system (x, y).
 
     Parameters
     ----------
     pols
-        A list with exactly two elements. Each element is parsed by :func:`parse_pol`.
+        A sequence with exactly two elements. Each element is parsed by :func:`parse_pol`.
 
     Raises
     ------
@@ -87,7 +87,7 @@ def to_linear(pols: list[str]) -> np.ndarray:
     return m
 
 
-def from_linear(pols: list[str]) -> np.ndarray:
+def from_linear(pols: Sequence[str]) -> np.ndarray:
     """Create a Jones matrix to convert to a linear coordinate system (x, y).
 
     See :func:`to_linear` for details. This function simply returns the inverse.

--- a/src/katcbf_vlbi_resample/polarisation.py
+++ b/src/katcbf_vlbi_resample/polarisation.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2025, National Research Foundation (SARAO)
+# Copyright (c) 2025-2026, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/src/katcbf_vlbi_resample/polarisation.py
+++ b/src/katcbf_vlbi_resample/polarisation.py
@@ -83,7 +83,7 @@ def to_linear(pols: Sequence[str]) -> np.ndarray:
         raise ValueError("pols must contain exactly two elements")
     m = np.column_stack([parse_pol(pol) for pol in pols])
     if np.linalg.matrix_rank(m) < 2:
-        raise ValueError(f"polarisations {','.join(pols)} do not form a basis")
+        raise ValueError(f"polarisations {','.join(pols)!r} do not form a basis")
     return m
 
 

--- a/src/katcbf_vlbi_resample/rechunk.py
+++ b/src/katcbf_vlbi_resample/rechunk.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2024, National Research Foundation (SARAO)
+# Copyright (c) 2024-2026, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/src/katcbf_vlbi_resample/resample.py
+++ b/src/katcbf_vlbi_resample/resample.py
@@ -325,14 +325,17 @@ class Resample:
             # leaves the phase of upfirdn intact for the next batch.
             stop -= (stop - self._fir_discard_left) % n
             if stop > self._fir_discard_left:
-                mix_scale = Fraction(self._mix_freq) * self._in_time_scale
-                # Compute the phase for the first sample using Fraction to avoid
-                # rounding errors creeping in when time_bias is large.
-                start_cycles = mix_scale * buffer.attrs["time_bias"]
-                start_cycles -= round(start_cycles)
-                mixer = _mixer(buffer, float(mix_scale), float(start_cycles))
-                mixed = buffer * mixer
-                mixed.attrs = buffer.attrs
+                if self._mix_freq != 0.0:
+                    mix_scale = Fraction(self._mix_freq) * self._in_time_scale
+                    # Compute the phase for the first sample using Fraction to avoid
+                    # rounding errors creeping in when time_bias is large.
+                    start_cycles = mix_scale * buffer.attrs["time_bias"]
+                    start_cycles -= round(start_cycles)
+                    mixer = _mixer(buffer, float(mix_scale), float(start_cycles))
+                    mixed = buffer * mixer
+                    mixed.attrs = buffer.attrs
+                else:
+                    mixed = buffer
                 convolved = _upfirdn(self._fir, mixed, self._ratio)
                 convolved = _split_sidebands(convolved, self._hilbert)
                 convolved = isel_time(convolved, np.s_[self._fir_discard_left : stop])

--- a/test/test_polarisation.py
+++ b/test/test_polarisation.py
@@ -37,7 +37,7 @@ class TestParseSpec:
         [
             ("x,y:x,y:x,y", "polarisation spec 'x,y:x,y:x,y' must contain exactly one colon"),
             ("x,y,x:x,y", "polarisation spec 'x,y,x' must contain exactly one comma"),
-            ("x,-x:x,y", "polarisations x,-x do not form a basis"),
+            ("x,-x:x,y", "polarisations 'x,-x' do not form a basis"),
             ("x,y:x,z", "polarisation 'z' must be x, y, R, L"),
         ],
     )

--- a/test/test_polarisation.py
+++ b/test/test_polarisation.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2025, National Research Foundation (SARAO)
+# Copyright (c) 2025-2026, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/test_polarisation.py
+++ b/test/test_polarisation.py
@@ -23,7 +23,7 @@ import pytest
 import xarray as xr
 from astropy.time import Time
 
-from katcbf_vlbi_resample.polarisation import ConvertPolarisation, parse_spec
+from katcbf_vlbi_resample.polarisation import ConvertPolarisation, parse_spec, to_linear
 from katcbf_vlbi_resample.utils import concat_time, is_cupy
 
 from . import SimpleStream
@@ -37,7 +37,7 @@ class TestParseSpec:
         [
             ("x,y:x,y:x,y", "polarisation spec 'x,y:x,y:x,y' must contain exactly one colon"),
             ("x,y,x:x,y", "polarisation spec 'x,y,x' must contain exactly one comma"),
-            ("x,-x:x,y", "polarisation spec 'x,-x' does not form a basis"),
+            ("x,-x:x,y", "polarisations x,-x do not form a basis"),
             ("x,y:x,z", "polarisation 'z' must be x, y, R, L"),
         ],
     )
@@ -70,6 +70,13 @@ class TestParseSpec:
         expected = np.array([[1, 1j], [1, -1j]]) * np.sqrt(0.5)
         np.testing.assert_allclose(parse_spec("x,y:R,L"), expected, rtol=1e-15)
         np.testing.assert_allclose(parse_spec("R,L:x,y"), np.linalg.inv(expected), rtol=1e-15)
+
+
+def test_to_linear_bad_length() -> None:
+    """Test error handling in :func:`katcbf_vlbi_resample.polarisation.to_linear."""
+    # The normal functionality is indirectly tested via TestParseSpec above.
+    with pytest.raises(ValueError, match="must contain exactly two elements"):
+        to_linear(["x", "y", "R"])
 
 
 class TestConvertPolarisation:

--- a/test/test_resample.py
+++ b/test/test_resample.py
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2024, National Research Foundation (SARAO)
+# Copyright (c) 2024-2026, National Research Foundation (SARAO)
 #
 # Licensed under the BSD 3-Clause License (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy

--- a/test/test_resample.py
+++ b/test/test_resample.py
@@ -129,10 +129,14 @@ class TestIFFT:
 class TestResample:
     """Test :class:`.Resample`."""
 
-    @pytest.fixture
-    def mixer_frequency(self) -> float:
-        """Difference between input and output centre frequencies."""
-        return 8e6
+    @pytest.fixture(params=[0.0, 8e6])
+    def mixer_frequency(self, request: pytest.FixtureRequest) -> float:
+        """Difference between input and output centre frequencies.
+
+        This fixture is parametrised to test both the fast path when
+        the mixer frequency is zero as well as the more general case.
+        """
+        return request.param
 
     @pytest.fixture
     def output_bandwidth(self) -> float:


### PR DESCRIPTION
- Allow polarisations to be labelled arbitrarily instead of only 'pol0', 'pol1'
- Expose the polarisation parsing API in a way that lets katgpucbf use just smaller pieces
- Eliminate StreamParameters so that when no mixing is needed, the centre frequency doesn't need to be known.
- Add a fast path so that when the mixer frequency is zero, no mixing is done.