### PR TITLE
Fix test failure with newer xarray

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
           - h5py==3.14.0
           - numpy==2.3.2
           - scipy==1.16.1
-          - xarray==2025.7.1
+          - xarray==2026.2.0
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.9.8
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "numpy",
     "packaging",
     "scipy",
-    "xarray",
+    "xarray>=2025.11.0",  # Changes keep_attrs default
 ]
 license = "BSD-3-Clause"
 license-files = ["LICENSE"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -175,5 +175,5 @@ urllib3==2.5.0
     # via requests
 virtualenv==20.32.0
     # via pre-commit
-xarray==2025.7.1
+xarray==2026.2.0
     # via katcbf-vlbi-resample (pyproject.toml)

--- a/test/test_power.py
+++ b/test/test_power.py
@@ -71,6 +71,7 @@ class TestMeasurePower:
             xp.full((2, 10), 4.5),
             dims=("pol", "time"),
             coords={"pol": ["h", "v"]},
+            attrs={"time_bias": 123},
             name="rms",
         )
         expected_rms[0] *= 2


### PR DESCRIPTION
Newer versions of xarray preserve attributes across computations. That accidentally fixed the bug that MeasurePower didn't provide the time_bias attribute in its output, and fixing the bug broke the test.

Fix the test, and set a lower bound on xarray so that we're sure to pick up this fix.