### PR TITLE
Speed up construction of VDIF header structures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ description = "Proof-of-concept of resampling tied-array-channelised-voltages fo
 requires-python = ">=3.12"
 dependencies = [
     "astropy",
-    "baseband",
     "numpy",
     "packaging",
     "scipy",
@@ -43,12 +42,14 @@ Documentation = "https://katcbf-vlbi-resample.readthedocs.io"
 [project.optional-dependencies]
 cli = [
     "atomicwrites",
+    "baseband",
     "h5py",
     "katsdptelstate[rdb]",
     "platformdirs",
     "rich",
 ]
 dev = [
+    "baseband",
     "build",
     "pre-commit",
     "pytest",

--- a/src/katcbf_vlbi_resample/mk.py
+++ b/src/katcbf_vlbi_resample/mk.py
@@ -29,7 +29,6 @@ from dataclasses import dataclass
 from typing import Any, BinaryIO, Self
 
 import astropy.units as u
-import baseband.vdif
 import h5py
 import katsdptelstate
 import numpy as np
@@ -319,7 +318,7 @@ async def async_main() -> None:  # noqa: D103
 
     # The above just sets up an iterator. Now use it to write to file.
     fns = iter(FileNameSequencer(args.output))
-    fh: baseband.vdif.VDIFFileWriter | None = None
+    fh: BinaryIO | None = None
     try:
         with Progress() as progress:
             task_id = progress.add_task("Processing...", total=n_spectra)
@@ -331,7 +330,7 @@ async def async_main() -> None:  # noqa: D103
                 if fh is None or fh.tell() + nbytes > args.file_size:
                     if fh is not None:
                         fh.close()
-                    fh = baseband.vdif.open(next(fns), "wb")
+                    fh = open(next(fns), "wb")
                 for frame in frameset:
                     fh.write(frame.header)
                     fh.write(frame.payload)

--- a/src/katcbf_vlbi_resample/mk.py
+++ b/src/katcbf_vlbi_resample/mk.py
@@ -29,7 +29,6 @@ from dataclasses import dataclass
 from typing import Any, BinaryIO, Self
 
 import astropy.units as u
-import baseband.base.encoding
 import baseband.vdif
 import h5py
 import katsdptelstate

--- a/src/katcbf_vlbi_resample/mk.py
+++ b/src/katcbf_vlbi_resample/mk.py
@@ -308,11 +308,10 @@ async def async_main() -> None:  # noqa: D103
         it_rms = RecordPower(it_rms, threads=threads, writer=csv.writer(power_fh))
     else:
         power_fh = None
-    # Normalise the power. The baseband package uses a threshold of
-    # TWO_BIT_1_SIGMA so we have to adjust the level to match.
-    it = power.NormalisePower(it_rms, baseband.base.encoding.TWO_BIT_1_SIGMA / args.threshold, power=args.normalise)
+    # Normalise the power.
+    it = power.NormalisePower(it_rms, 1.0, power=args.normalise)
     # Encode to VDIF
-    it = vdif_writer.VDIFEncode2Bit(it, samples_per_frame=args.samples_per_frame)
+    it = vdif_writer.VDIFEncode2Bit(it, samples_per_frame=args.samples_per_frame, threshold=args.threshold)
     # Transfer back to the CPU if needed
     if is_cupy:
         it = cupy_bridge.AsNumpy(it)

--- a/src/katcbf_vlbi_resample/mk.py
+++ b/src/katcbf_vlbi_resample/mk.py
@@ -326,11 +326,16 @@ async def async_main() -> None:  # noqa: D103
             task_id = progress.add_task("Processing...", total=n_spectra)
             progress_it.set_progress(progress, task_id)
             async for frameset in frameset_it:
-                if fh is None or fh.tell() + frameset.nbytes > args.file_size:
+                nbytes = 0
+                for frame in frameset:
+                    nbytes += frame.header.nbytes + frame.payload.nbytes
+                if fh is None or fh.tell() + nbytes > args.file_size:
                     if fh is not None:
                         fh.close()
                     fh = baseband.vdif.open(next(fns), "wb")
-                frameset.tofile(fh)
+                for frame in frameset:
+                    fh.write(frame.header)
+                    fh.write(frame.payload)
     finally:
         if fh is not None:
             fh.close()

--- a/src/katcbf_vlbi_resample/mk.py
+++ b/src/katcbf_vlbi_resample/mk.py
@@ -30,6 +30,7 @@ from typing import Any, BinaryIO, Self
 
 import astropy.units as u
 import baseband.base.encoding
+import baseband.vdif
 import h5py
 import katsdptelstate
 import numpy as np

--- a/src/katcbf_vlbi_resample/vdif_writer.py
+++ b/src/katcbf_vlbi_resample/vdif_writer.py
@@ -25,35 +25,34 @@ import cupy as cp
 import numpy as np
 import xarray as xr
 from astropy.time import Time, TimeDelta
-from baseband.base.encoding import TWO_BIT_1_SIGMA
 
 from .stream import Stream
 from .utils import concat_time, isel_time, time_align
 
 
 @cp.fuse
-def _encode_2bit_prep(values):
-    xp = cp.get_array_module(values)
-    return xp.clip(values * (1 / TWO_BIT_1_SIGMA) + 2, 0, 3).astype(np.uint8)
+def _encode_2bit_prep(values, scale: float):
+    xp = cp.get_array_module(values, scale)
+    return xp.clip(values * scale + 2, 0, 3).astype(np.uint8)
 
 
-def _encode_2bit(values):
+def _encode_2bit(values, threshold: float):
     """Encode values using 2 bits per value, packing the result into bytes.
 
-    This is equivalent to :func:`baseband.vdif.encode_2bit`, but supports
-    cupy. Note that values very close to the threshold might round
-    differently.
+    This is equivalent to :func:`baseband.vdif.encode_2bit` but it supports a
+    custom threshold and cupy. Note that values very close to the threshold
+    might round differently.
     """
     xp = cp.get_array_module(values)
-    values = _encode_2bit_prep(values)
+    values = _encode_2bit_prep(values, 1.0 / threshold)
     values = values.reshape(values.shape[:-1] + (-1, 4))
     values <<= xp.arange(0, 8, 2, dtype=np.uint8)
     # cupy doesn't currently support np.bitwise_or.reduce
     return values[..., 0] | values[..., 1] | values[..., 2] | values[..., 3]
 
 
-def _encode_2bit_words(values):
-    return _encode_2bit(values).view("<u4")
+def _encode_2bit_words(values, threshold: float):
+    return _encode_2bit(values, threshold).view("<u4")
 
 
 def _reference_epoch(time: Time) -> tuple[Time, int]:
@@ -84,8 +83,9 @@ def _reference_epoch(time: Time) -> tuple[Time, int]:
 class VDIFEncode2Bit:
     """Quantise and pack values to 2-bit samples.
 
-    The power levels must have already been adjusted such that :mod:`baseband`
-    will quantise correctly.
+    Values are quantised by comparing the absolute value to `threshold`.
+    The power levels must already have been adjusted to make this an
+    threshold appropriate.
 
     The output array is in units of VDIF words (32-bit little-endian) rather
     than samples, and `time_bias` is also in units of words. Only real-valued
@@ -100,7 +100,7 @@ class VDIFEncode2Bit:
 
     SAMPLES_PER_WORD: Final = 16
 
-    def __init__(self, input_data: Stream[xr.DataArray], samples_per_frame: int) -> None:
+    def __init__(self, input_data: Stream[xr.DataArray], samples_per_frame: int, threshold: float) -> None:
         if input_data.channels is not None:
             raise ValueError("VDIFEncoder2Bit currently only supports unchannelised data")
         # VDIF requires an even number of words per frame
@@ -123,6 +123,7 @@ class VDIFEncode2Bit:
         self.time_scale = input_data.time_scale * self.SAMPLES_PER_WORD
         self.channels = None
         self.is_cupy = input_data.is_cupy
+        self.threshold = threshold
 
     async def __aiter__(self) -> AsyncIterator[xr.DataArray]:
         samples_per_frame = self.samples_per_frame
@@ -145,6 +146,7 @@ class VDIFEncode2Bit:
                 output_core_dims=[("time",)],
                 exclude_dims={"time"},
                 keep_attrs=True,
+                kwargs=dict(threshold=self.threshold),
             )
             assert encoded.attrs["time_bias"] % self.SAMPLES_PER_WORD == 0
             encoded.attrs["time_bias"] //= self.SAMPLES_PER_WORD

--- a/src/katcbf_vlbi_resample/vdif_writer.py
+++ b/src/katcbf_vlbi_resample/vdif_writer.py
@@ -17,15 +17,15 @@
 """Encode data to VDIF frames."""
 
 from collections.abc import AsyncIterator
+from dataclasses import dataclass
 from fractions import Fraction
 from typing import Any, Final
 
 import cupy as cp
 import numpy as np
 import xarray as xr
-from astropy.time import TimeDelta
+from astropy.time import Time, TimeDelta
 from baseband.base.encoding import TWO_BIT_1_SIGMA
-from baseband.vdif import VDIFFrame, VDIFFrameSet, VDIFHeader, VDIFPayload
 
 from .stream import Stream
 from .utils import concat_time, isel_time, time_align
@@ -54,6 +54,31 @@ def _encode_2bit(values):
 
 def _encode_2bit_words(values):
     return _encode_2bit(values).view("<u4")
+
+
+def _reference_epoch(time: Time) -> tuple[Time, int]:
+    """Compute the VDIF reference epoch to use.
+
+    VDIF has a reference epoch every 6 months, with 0 corresponding to
+    00:00:00 UTC on 1 Jan 2000. This function will pick the latest
+    reference epoch prior to (or equal to) `time`.
+
+    Returns
+    -------
+    ref_time
+        The UTC time corresponding to the chosen reference epoch.
+    epoch
+        Index of the epoch. It is *not* truncated to 6 bits.
+    """
+    t = time.utc.ymdhms
+    if t.year < 2000:
+        raise ValueError("Times before 2000 cannot be used with VDIF")
+    epoch = (t.year - 2000) * 2
+    ref_month = 1
+    if t.month >= 7:
+        epoch += 1
+        ref_month = 7
+    return Time(dict(year=t.year, month=ref_month, day=1), scale="utc"), epoch
 
 
 class VDIFEncode2Bit:
@@ -99,7 +124,7 @@ class VDIFEncode2Bit:
         self.channels = None
         self.is_cupy = input_data.is_cupy
 
-    async def __aiter__(self) -> AsyncIterator[VDIFFrameSet]:
+    async def __aiter__(self) -> AsyncIterator[xr.DataArray]:
         samples_per_frame = self.samples_per_frame
         buffer = None
         async for in_data in self._input_it:
@@ -129,6 +154,48 @@ class VDIFEncode2Bit:
             buffer = isel_time(buffer, np.s_[skip:])
 
 
+@dataclass
+class VDIFFrame:
+    """Combines a VDIF header and payload in a data class."""
+
+    header: np.ndarray
+    payload: np.ndarray
+
+
+def _make_header(
+    *,
+    bps: int,
+    station: str | int,
+    samples_per_frame: int,
+    ref_time: Time,
+) -> tuple[np.ndarray, Time]:
+    """Generate a template of the VDIF header, without per-frame timing data."""
+
+    def field(name: str, word: int, offset: int, bits: int, value: int) -> None:
+        assert offset + bits <= 32
+        if value >= 1 << bits:
+            raise ValueError(f"{name} does not fit in the {bits}-bit VDIF header field")
+        header[word] |= value << offset
+
+    header = np.zeros(8, "<u4")
+    ref_time, epoch = _reference_epoch(ref_time)
+    epoch &= 0x3F  # VDIF only uses the bottom 6 bits, wrapping in 2032
+    field("ref epoch", 1, 24, 6, epoch)
+    if samples_per_frame * bps % 64 != 0:
+        raise ValueError("samples_per_frame does not yield a whole number of 8-byte units")
+    field("data frame length", 2, 0, 24, samples_per_frame * bps // 64 + 4)
+    field("version", 2, 29, 3, 1)
+    if isinstance(station, int):
+        if station < 0 or station >= 0x3000:
+            raise ValueError("numeric station ID is out of range")
+        field("station ID", 3, 0, 16, station)
+    else:
+        # TODO: check that it's ASCII and the first character is >= '0'
+        field("station ID", 3, 0, 16, (ord(station[0]) << 8) | ord(station[1]))
+    field("bits/sample", 3, 26, 5, bps - 1)
+    return header, ref_time
+
+
 class VDIFFormatter:
     """Encode data to VDIF frames.
 
@@ -156,15 +223,13 @@ class VDIFFormatter:
         if samples_per_frame % (2 * VDIFEncode2Bit.SAMPLES_PER_WORD) != 0:
             raise ValueError(f"samples_per_frame must be a multiple of {2 * VDIFEncode2Bit.SAMPLES_PER_WORD}")
         self._input_it = aiter(input_data)
-        self._header = VDIFHeader.fromvalues(
+        self._header, ref_time = _make_header(
             bps=2,
-            complex_data=False,
-            nchan=1,
             station=station,
             samples_per_frame=samples_per_frame,
             ref_time=input_data.time_base,
-            edv=0,
         )
+        self._samples_per_frame = samples_per_frame
         self._threads = threads
         words_per_frame = samples_per_frame // VDIFEncode2Bit.SAMPLES_PER_WORD
         frame_rate = 1 / (words_per_frame * input_data.time_scale)
@@ -172,7 +237,7 @@ class VDIFFormatter:
             raise ValueError("samples_per_frame does not yield an integer frame rate")
         self._frame_rate = int(frame_rate)
         #: Number of VDIF seconds corresponding to a time_bias of 0
-        base_seconds = (input_data.time_base - self._header.ref_time).sec
+        base_seconds = (input_data.time_base - ref_time).sec
         self._base_seconds = round(base_seconds)
         if abs(base_seconds - self._base_seconds) > 1e-8:
             raise ValueError("time_base was not aligned to a second boundary")
@@ -182,26 +247,19 @@ class VDIFFormatter:
         self.channels = None
         self.is_cupy = False
 
-    def _frame(self, thread_id: int, header: VDIFHeader, frame_data: np.ndarray) -> VDIFFrame:
+    def _frame(self, thread_id: int, header: np.ndarray, frame_data: np.ndarray) -> VDIFFrame:
         header = header.copy()
-        header.update(thread_id=thread_id)
-        return VDIFFrame(
-            header,
-            VDIFPayload(frame_data, header),
-        )
+        header[3] |= thread_id << 16
+        return VDIFFrame(header, frame_data)
 
-    def _frame_set(self, frame: int, frame_data: list[np.ndarray]) -> VDIFFrameSet:
+    def _frame_set(self, frame: int, frame_data: list[np.ndarray]) -> list[VDIFFrame]:
         header = self._header.copy()
-        header.update(
-            seconds=self._base_seconds + frame // self._frame_rate,
-            frame_nr=frame % self._frame_rate,
-        )
+        header[0] = self._base_seconds + frame // self._frame_rate
+        header[1] |= frame % self._frame_rate
+        return [self._frame(i, header, thread) for i, thread in enumerate(frame_data)]
 
-        frames = [self._frame(i, header, thread) for i, thread in enumerate(frame_data)]
-        return VDIFFrameSet(frames, header)
-
-    async def __aiter__(self) -> AsyncIterator[VDIFFrameSet]:
-        words_per_frame = self._header.samples_per_frame // VDIFEncode2Bit.SAMPLES_PER_WORD
+    async def __aiter__(self) -> AsyncIterator[list[VDIFFrame]]:
+        words_per_frame = self._samples_per_frame // VDIFEncode2Bit.SAMPLES_PER_WORD
         async for buffer in self._input_it:
             n_frames = buffer.sizes["time"] // words_per_frame
             # xarray's overheads are too high to use it on a per-frame basis.

--- a/src/katcbf_vlbi_resample/vdif_writer.py
+++ b/src/katcbf_vlbi_resample/vdif_writer.py
@@ -30,10 +30,13 @@ from .stream import Stream
 from .utils import concat_time, isel_time, time_align
 
 
+# Note: the caller must pass the inverse of the threshold here. Computing
+# the inverse inside this function would cause it to happen per-element on
+# the GPU (much more expensive) rather than per-array in the Python code.
 @cp.fuse
-def _encode_2bit_prep(values, scale: float):
-    xp = cp.get_array_module(values, scale)
-    return xp.clip(values * scale + 2, 0, 3).astype(np.uint8)
+def _encode_2bit_prep(values, inverse_threshold: float):
+    xp = cp.get_array_module(values)
+    return xp.clip(values * inverse_threshold + 2, 0, 3).astype(np.uint8)
 
 
 def _encode_2bit(values, threshold: float):

--- a/test/test_vdif_writer.py
+++ b/test/test_vdif_writer.py
@@ -35,6 +35,63 @@ from katcbf_vlbi_resample.utils import concat_time, fraction_to_time_delta
 from . import SimpleStream
 
 
+# astropy warns about times in the distant future (presumably because
+# leap-seconds are not known).
+@pytest.mark.filterwarnings("ignore:.*dubious year.*")
+@pytest.mark.parametrize(
+    "time, ref_time, epoch",
+    [
+        ("2000-01-01 00:00:00", "2000-01-01 00:00:00", 0),
+        ("2015-06-30 23:59:60", "2015-01-01 00:00:00", 30),  # Leap second
+        ("2025-03-02 12:34:56", "2025-01-01 00:00:00", 50),
+        ("2025-09-01 12:34:56", "2025-07-01 00:00:00", 51),
+        ("2032-01-01 00:00:00", "2032-01-01 00:00:00", 64),  # _reference_epoch shouldn't wrap at 6 bits
+    ],
+)
+def test_reference_epoch(time: str, ref_time: str, epoch: int) -> None:
+    """Test :func:`katcbf_vlbi_resample.vdif_writer._reference_epoch."""
+    time_a = Time(time, format="iso", scale="utc")
+    ref_time_a = Time(ref_time, format="iso", scale="utc")
+    assert vdif_writer._reference_epoch(time_a) == (ref_time_a, epoch)
+
+
+def test_make_header() -> None:
+    """Test :func:`katcbf_vlbi_resample.vdif_writer._make_header.
+
+    There is also indirect testing in TestVDIFFormatter which covers cases not
+    tested here (particularly non-numeric station IDs).
+    """
+    header, ref_time = vdif_writer._make_header(
+        bps=2,
+        station=1234,
+        samples_per_frame=96,
+        ref_time=Time("2025-09-01 12:34:56", format="iso", scale="utc"),
+    )
+    assert ref_time == Time("2025-07-01 00:00:00", format="iso", scale="utc")
+    parsed = baseband.vdif.header.VDIFHeader(header)
+    assert parsed.bps == 2
+    assert parsed.station == 1234
+    assert parsed.samples_per_frame == 96
+    assert parsed["ref_epoch"] == 51
+    # Check that fields that are meant to be blank in fact are
+    assert parsed["thread_id"] == 0
+    assert parsed["seconds"] == 0
+    assert parsed["frame_nr"] == 0
+
+
+def test_make_header_bad() -> None:
+    """Test exception handling in :func:`katcbf_vlbi_resample.vdif_writer._make_header`."""
+    ref_time = Time("2025-09-01 12:34:56", format="iso", scale="utc")
+    with pytest.raises(ValueError, match="bits/sample does not fit in the 5-bit VDIF header field"):
+        vdif_writer._make_header(bps=33, station="me", samples_per_frame=256, ref_time=ref_time)
+    with pytest.raises(ValueError, match="numeric station ID is out of range"):
+        vdif_writer._make_header(bps=2, station=-1, samples_per_frame=96, ref_time=ref_time)
+    with pytest.raises(ValueError, match="numeric station ID is out of range"):
+        vdif_writer._make_header(bps=2, station=0x3000, samples_per_frame=96, ref_time=ref_time)
+    with pytest.raises(ValueError, match="samples_per_frame does not yield a whole number of 8-byte units"):
+        vdif_writer._make_header(bps=3, station="me", samples_per_frame=96, ref_time=ref_time)
+
+
 @pytest.fixture
 def input_data(xp) -> xr.DataArray:
     """Input data, as a single chunk."""
@@ -167,6 +224,9 @@ class TestVDIFFormatter:
             assert vdif_data.shape == data.shape[::-1]
             assert vdif_data.sample_shape == (2,)
             assert (vdif_data.start_time - time_base).sec == pytest.approx(0.002, abs=1e-10)
+            # For some reason baseband only exposes this as a key, not an attribute
+            assert vdif_data.header0["vdif_version"] == 1
+            assert vdif_data.header0.nchan == 1
             assert vdif_data.header0.station == "me"
             out_data = xr.DataArray(
                 vdif_data.read(),

--- a/test/test_vdif_writer.py
+++ b/test/test_vdif_writer.py
@@ -26,7 +26,7 @@ import numpy as np
 import pytest
 import xarray as xr
 from astropy.time import Time, TimeDelta
-from baseband.base.encoding import OPTIMAL_2BIT_HIGH
+from baseband.base.encoding import OPTIMAL_2BIT_HIGH, TWO_BIT_1_SIGMA
 from baseband.vdif.payload import encode_2bit
 
 from katcbf_vlbi_resample import vdif_writer
@@ -59,7 +59,7 @@ class TestEncode2Bit:
         rng = xp.random.default_rng(seed=2)
         data = rng.uniform(-5.0, 5.0, size=(100000,)).astype(xp.float32)
         expected = encode_2bit(cp.asnumpy(data))
-        actual = vdif_writer._encode_2bit(data)
+        actual = vdif_writer._encode_2bit(data, TWO_BIT_1_SIGMA)
         # Note: values right on the threshold might round differently,
         # but do not currently seem to do so. Changes to cupy's random
         # generator may require adjustments to the test to allow for
@@ -73,16 +73,16 @@ class TestVDIFEncode2Bit:
     def test_bad_samples_per_frame_word_align(self, orig: SimpleStream[xr.DataArray]) -> None:
         """Test that `samples_per_frame` not a multiple of word size raises :exc:`ValueError`."""
         with pytest.raises(ValueError, match="samples_per_frame must be a multiple of 32"):
-            vdif_writer.VDIFEncode2Bit(orig, 160016)
+            vdif_writer.VDIFEncode2Bit(orig, 160016, 1.0)
 
     def test_bad_samples_per_frame_rate(self, orig: SimpleStream[xr.DataArray]) -> None:
         """Test that ValueError is raised if frame rate is not an integer."""
         with pytest.raises(ValueError, match="samples_per_frame does not yield an integer frame rate"):
-            vdif_writer.VDIFEncode2Bit(orig, 160032)
+            vdif_writer.VDIFEncode2Bit(orig, 160032, 1.0)
 
     async def test_success(self, xp, orig: SimpleStream[xr.DataArray], input_data: xr.DataArray) -> None:
         """Test normal usage."""
-        enc = vdif_writer.VDIFEncode2Bit(orig, 160)
+        enc = vdif_writer.VDIFEncode2Bit(orig, 160, 1.0)
         assert enc.time_scale == orig.time_scale * vdif_writer.VDIFEncode2Bit.SAMPLES_PER_WORD
         assert enc.is_cupy == orig.is_cupy
         chunks = [chunk async for chunk in enc]
@@ -97,7 +97,7 @@ class TestVDIFEncode2Bit:
         assert abs(actual_start - expected_start) <= TimeDelta(1e-10, format="sec")
         assert out_data.sizes["time"] == 480 // vdif_writer.VDIFEncode2Bit.SAMPLES_PER_WORD
         used_input_data = input_data.isel(time=xp.s_[23:503])
-        xp.testing.assert_array_equal(out_data.data, vdif_writer._encode_2bit_words(used_input_data.data))
+        xp.testing.assert_array_equal(out_data.data, vdif_writer._encode_2bit_words(used_input_data.data, 1.0))
 
 
 class TestVDIFFormatter:
@@ -145,7 +145,8 @@ class TestVDIFFormatter:
         )
         samples_per_frame = 160
         orig = SimpleStream.factory(time_base, time_scale, data, 100)
-        enc = vdif_writer.VDIFEncode2Bit(orig, samples_per_frame)
+        # TWO_BIT_1_SIGMA gives compatibility with baseband's encoding
+        enc = vdif_writer.VDIFEncode2Bit(orig, samples_per_frame, TWO_BIT_1_SIGMA)
         fmt = vdif_writer.VDIFFormatter(
             enc, [{"pol": "h"}, {"pol": "v"}], station="me", samples_per_frame=samples_per_frame
         )

--- a/test/test_vdif_writer.py
+++ b/test/test_vdif_writer.py
@@ -153,7 +153,9 @@ class TestVDIFFormatter:
         # Write the data to an in-memory file
         fh = io.BytesIO()
         async for frameset in fmt:
-            frameset.tofile(fh)
+            for frame in frameset:
+                fh.write(frame.header)
+                fh.write(frame.payload)
 
         # Read it back and compare to the original data
         fh.seek(0, 0)


### PR DESCRIPTION
Previously I used the baseband package to do this, but it's very slow because it does sanity checks all over the place and is very generic. Rip out baseband entirely from the core library (it's still used for tests and CLI utils). You can find the specification for the header layout at https://vlbi.org/wp-content/uploads/2019/03/VDIF_specification_Release_1.1.1.pdf (we are not using any EDV headers).

This is a breaking change, because VDIFFormatter used to yield baseband's VDIFFrameSet class. It now just yields a `list[VDIFFrame]` where VDIFFrame is an internally-defined class containing numpy arrays that can be dumped on the wire.

To eliminate baseband from the rest of the library (where it was only used for one magic constant, which was only used to make the behaviour match that of baseband) I changes VDIFEncode2Bit to take the quantisation threshold explicitly, which simplifies some other code. That's another breaking change, but since I'd made one I figured I'd make another.

Checklist:
- [x] Test the command-line tool again.