### PR TITLE
Reduce memory usage for VDIFEncode2Bit

### DIFF
--- a/src/katcbf_vlbi_resample/utils.py
+++ b/src/katcbf_vlbi_resample/utils.py
@@ -31,12 +31,22 @@ def concat_time(arrays: Sequence[xr.DataArray]) -> xr.DataArray:
 
     This checks that the arrays are contiguous in time and fixes up the
     timestamping attribute.
+
+    It also has a fast path if there is only one non-empty array in
+    the sequence, in which case that array is returned without making
+    a copy. Note that this means that the original arrays cannot safely
+    be modified, as it will affect the return value.
     """
     n = 0
+    non_empty = []
     for array in arrays:
         if array.attrs["time_bias"] != arrays[0].attrs["time_bias"] + n:
             raise ValueError("Chunks are not contiguous in time")
+        if array.sizes["time"] != 0:
+            non_empty.append(array)
         n += array.sizes["time"]
+    if len(non_empty) == 1:
+        return non_empty[0]
     # Simply using xr.concat is slow because it builds an index on the
     # concatenated axis. This is hacky and will probably lose coordinates
     # in the general case, but is sufficient for the uses in this library.

--- a/src/katcbf_vlbi_resample/vdif_writer.py
+++ b/src/katcbf_vlbi_resample/vdif_writer.py
@@ -156,9 +156,10 @@ class VDIFEncode2Bit:
             encoded.attrs["time_bias"] //= self.SAMPLES_PER_WORD
             yield encoded
             del encoded
-            # Cut off the piece that's been processed
+            # Cut off the piece that's been processed. We then copy the
+            # tail piece so that the bulk of the memory can be freed.
             skip = n_frames * samples_per_frame
-            buffer = isel_time(buffer, np.s_[skip:])
+            buffer = isel_time(buffer, np.s_[skip:]).copy()
 
 
 @dataclass

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -58,6 +58,16 @@ class TestConcatTime:
             attrs={"time_bias": 38},
         )
 
+    @pytest.fixture
+    def empty_array(self, xp) -> xr.DataArray:
+        """Create an array with zero length on the time axis."""
+        return xr.DataArray(
+            xp.zeros((0, 2), dtype=xp.uint8),
+            dims=("time", "pol"),
+            coords={"pol": ["h", "v"]},
+            attrs={"time_bias": 38},
+        )
+
     def test_success(self, xp, array1: xr.DataArray, array2: xr.DataArray) -> None:
         """Test the normal usage path."""
         out = concat_time([array1, array2])
@@ -68,6 +78,11 @@ class TestConcatTime:
             out.data,
             [[10, 11, 12, 13, 14, 1, 1, 1], [15, 16, 17, 18, 19, 1, 1, 1]],
         )
+
+    def test_return_view(self, xp, array2: xr.DataArray, empty_array: xr.DataArray) -> None:
+        """Test the fast path that returns an input array if it is the only non-empty one."""
+        out = concat_time([empty_array, array2])
+        assert out is array2
 
     def test_non_contiguous(self, array1: xr.DataArray, array2: xr.DataArray) -> None:
         """Test that an exception is raised if the `time_bias` fields are inconsistent."""


### PR DESCRIPTION
There are two optimisations:

1. Each iteration processes a whole number of frames, and may have a partial frame left over in the buffer. It used isel_time to select only the left-over piece, but since that's just a view of the whole buffer, the whole buffer remained in memory. Copy the left-over piece (which will typically be zero-sized, since the signal chain passes through an alignment to UTC timestamps and VDIF requires frames to be UTC-aligned) so that the bulk of the buffer can be freed.

2. When we get a new chunk of data, it is concatenated with the left-over piece from the previous iteration. If that left-over piece is empty, this just becomes a copy operation, which we can skip.

Relates to NGC-1928.